### PR TITLE
Added option to randomize usernames before attempting user enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Parameters:
     -d	domain
     -o  output file
     -t  manually set timeout
+	-r  Randomize the user input list
 ```
 In this mode lyncsmash will enumerate usernames via a timing attack, using the Webticket service located on the Lync Front-End server. If a bad username and/or domain is specified, the response will be long. If it is a valid user, the response will be short. Due to limitations of the timing-attack, this can only be run single-threaded.
 

--- a/lyncsmash.py
+++ b/lyncsmash.py
@@ -186,9 +186,11 @@ def timing_attack(host,userfilepath,password,domain, randomize):
 		except Exception:
 			pass
 
-              #print ''
+        endtime=datetime.datetime.now()
+        elapsed_time=endtime - currenttime
+        f.write("Finished lyncsmash at {0}\n".format(currenttime))
+        f.write("Elapsed time {0}\n".format(elapsed_time))
         user_file.close()
-
 
 
 # Determine the baseline timeout for invalid username

--- a/lyncsmash.py
+++ b/lyncsmash.py
@@ -36,6 +36,7 @@ def main():
         enum_parser = subparsers.add_parser('enum', help='Enumerate valid Lync usernames')
         enum_parser.add_argument('-H', dest='host', help='Target IP address or host', required=True)
         enum_parser.add_argument('-U', dest='usernames', help='Username file', required=True)
+        enum_parser.add_argument('-r', action='store_true', dest='randomize', help='Randomize usernames from input file', required=False)
         enum_parser.add_argument('-d', dest='domain', help='Internal domain name', required=True)
         enum_parser.add_argument('-p', dest='passwd', help='Password to attempt', required=False)
         enum_parser.add_argument('-P', dest='passwdfile', help='Password file to read from', required=False)
@@ -80,12 +81,12 @@ def main():
                         if timeout:
                                 print_status("Average timeout is: {0}".format(timeout))
                                 if (args.passwd != None):
-                                    timing_attack(args.host.rstrip(), args.usernames.rstrip(), args.passwd.rstrip(), args.domain.rstrip())
+                                    timing_attack(args.host.rstrip(), args.usernames.rstrip(), args.passwd.rstrip(), args.domain.rstrip(), args.randomize)
 
                                 if (args.passwdfile != None):
                                     with open(args.passwdfile) as pass_file:
                                         for password in pass_file:
-                                            timing_attack(args.host.rstrip(), args.usernames.rstrip(), password.rstrip(), args.domain.rstrip())
+                                            timing_attack(args.host.rstrip(), args.usernames.rstrip(), password.rstrip(), args.domain.rstrip(), args.randomize)
 
                                     pass_file.close()
 
@@ -150,7 +151,7 @@ def discover_lync(host):
 
         return indicator_count, switch.get(indicator_count, 'Definitely')
 
-def timing_attack(host,userfilepath,password,domain):
+def timing_attack(host,userfilepath,password,domain, randomize):
 
     global outputfile
 
@@ -158,7 +159,10 @@ def timing_attack(host,userfilepath,password,domain):
         currenttime=datetime.datetime.now()
         f.write("Started lyncsmash at {0}\n".format(currenttime))
         with open(os.path.abspath(userfilepath)) as user_file:
-             for user in user_file:
+            user_list = [line.strip() for line in user_file]
+            if randomize:
+                random.shuffle(user_list)
+            for user in user_list:
 		try:
                  response_time = send_xml(host.rstrip(), domain.rstrip(), user.rstrip(), password.rstrip())
 		 candidatevalue=float(float(response_time)/timeout)


### PR DESCRIPTION
If you suspect a pattern in usernames and you create a long list (usr10000 - usr99999) using crunch, it can be quicker to use the -r (randomize) to easier find in the range the usernames are in.

 